### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/internal/transport/http/handlers/websocket/websocket.go
+++ b/internal/transport/http/handlers/websocket/websocket.go
@@ -422,7 +422,6 @@ func (c *Client) handleMessage(message []byte) {
 
 	c.logger.WithFields(logrus.Fields{
 		"client_id": c.ID,
-		"user_id":   c.UserID,
 		"type":      msg.Type,
 	}).Debug("Received WebSocket message")
 


### PR DESCRIPTION
Potential fix for [https://github.com/brokle-ai/brokle/security/code-scanning/10](https://github.com/brokle-ai/brokle/security/code-scanning/10)

To fix the problem, we should avoid logging sensitive data (`user_id`) in clear-text logs. The simplest and safest solution (without impacting existing system behaviors) is to redact, obfuscate, or remove this field from log outputs wherever they originate from user-supplied authentication contexts (e.g., apiKey or JWT). Here, we remove or redact `user_id` from the log entry in the `handleMessage` method, as the rest of the information (such as `client_id` and `type`) is sufficient for debugging and tracing connections.

The code change is within `internal/transport/http/handlers/websocket/websocket.go`, in the `handleMessage` method (`c.logger.WithFields`). We remove the `"user_id": c.UserID,` field from the log. Optionally, we can substitute it with a constant string like "[REDACTED]" or truncate it to a safe length/hashing if uniquely identifying users is necessary for troubleshooting (but only if that's justifiable). In most cases, simply omitting is best.

No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
